### PR TITLE
Add install script for disabling librdkafka from node-rdkafa transiti…

### DIFF
--- a/nodejs/install.sh
+++ b/nodejs/install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+BUILD_LIBRDKAFKA=0 npm install


### PR DESCRIPTION
Add a script for disabling building librdkafka when installing node-rdkafka dependencies. But the process node-glyph rebuild always check the library headers. This script can reduce the waiting time in node-rdkafka installation.